### PR TITLE
Improved message in index counter output

### DIFF
--- a/lua/autorun/sh_indexcounter.lua
+++ b/lua/autorun/sh_indexcounter.lua
@@ -42,11 +42,13 @@ concommand.Add( cmd, function( ply, _, args )
         table.sort( indexed, function( a, b ) return a.count > b.count end )
 
         local max = 100
+        local max_count = indexed[1].count
+
         for _, data in ipairs( indexed ) do
             max = max - 1
             if max < 0 then break end
 
-            print( data.count, data.origin )
+            MsgC( Color( 255, 255 - ( data.count / max_count * 255 ), 0 ), data.count, color_white, " | ", data.origin, "\n" )
         end
 
         if CLIENT then


### PR DESCRIPTION
Index part in `red_(cl/sv)_indexperf` output is now colorized based on the maximum index, gradually starts from red and gets up to yellow based on `(index / max_index)` and max_index is the first one in list.

<details>
<summary>Preview</summary>

![4KeyIPqx](https://github.com/wrefgtzweve/gmod_perfutils/assets/81193284/d2e41269-a5a3-407a-a764-116cdba093b8)
</details>

