### PR TITLE
Add srlion's hook lib priorities support

### DIFF
--- a/lua/autorun/sh_hookorder.lua
+++ b/lua/autorun/sh_hookorder.lua
@@ -7,12 +7,44 @@ local pink = Color( 235, 52, 137 )
 
 local hookRanNum = 0
 
+-- support for srlion's hook library priorities
+local function GetInternalHooks()
+    if hook.Author ~= "Srlion" then return end
+    local i = 0
+
+    while true do
+        i = i + 1
+
+        local name, value = debug.getupvalue( hook.Call, i )
+        if not name then break end
+
+        if name == "events" then
+            return value
+        end
+    end
+end
+
+local function GetHookPriority( internalHooks, hookName, hookID )
+    if not internalHooks then return end
+
+    local event = internalHooks[hookName]
+    if not event then return end
+
+    local hookInfo = event[hookID]
+    if not hookInfo then return end
+
+    return hookInfo.priority
+end
+
 local function wrapHooks( hookTable, hookName, hookCount )
     hookRanNum = 0
+    local internalHooks = GetInternalHooks()
+
     for hookID, originalFunc in pairs( hookTable ) do
         local originInfo = debug.getinfo( originalFunc, "S" )
         local hookFuncOrigin = originInfo.short_src
         local hookFuncLastDefined = originInfo.lastlinedefined
+        local priority = GetHookPriority( internalHooks, hookName, hookID )
 
         local wrappedHook = function( ... )
             hookRanNum = hookRanNum + 1
@@ -40,10 +72,10 @@ local function wrapHooks( hookTable, hookName, hookCount )
                 MsgC( pink, "Done!\n" )
             end
 
-            hook.Add( hookName, hookID, originalFunc )
+            hook.Add( hookName, hookID, originalFunc, priority )
             return a, b, c, d, e, f
         end
-        hook.Add( hookName, hookID, wrappedHook )
+        hook.Add( hookName, hookID, wrappedHook, priority )
     end
 end
 

--- a/lua/autorun/sh_hookperf.lua
+++ b/lua/autorun/sh_hookperf.lua
@@ -18,6 +18,23 @@ local function printer( ... )
     MsgC( unpack( order ) )
 end
 
+-- support for srlion's hook library priorities
+local function GetInternalHooks()
+    if hook.Author ~= "Srlion" then return end
+    local i = 0
+
+    while true do
+        i = i + 1
+
+        local name, value = debug.getupvalue( hook.Call, i )
+        if not name then break end
+
+        if name == "events" then
+            return value
+        end
+    end
+end
+
 local cmd = SERVER and "red_sv_hookperf" or "red_cl_hookperf"
 concommand.Add( cmd, function( ply, _, args )
     if SERVER and IsValid( ply ) and not ply:IsSuperAdmin() then
@@ -35,12 +52,20 @@ concommand.Add( cmd, function( ply, _, args )
     HOOK_PERF_ORIGINALS = HOOK_PERF_ORIGINALS or {}
     HOOK_PERF_RUNNING = true
 
+    local internalHooks = GetInternalHooks()
+
     for hookName, hookTable in pairs( hook.GetTable() ) do
         for hookEvent, hookFunc in pairs( hookTable ) do
-            HOOK_PERF_ORIGINALS[hookName] = HOOK_PERF_ORIGINALS[hookName] or {}
-            HOOK_PERF_ORIGINALS[hookName][hookEvent] = HOOK_PERF_ORIGINALS[hookName][hookEvent] or hookFunc
+            local priority
 
-            local originalFunc = HOOK_PERF_ORIGINALS[hookName][hookEvent]
+            if internalHooks and internalHooks[hookName] and internalHooks[hookName][hookEvent] then
+                priority = internalHooks[hookName][hookEvent].priority
+            end
+
+            HOOK_PERF_ORIGINALS[hookName] = HOOK_PERF_ORIGINALS[hookName] or {}
+            HOOK_PERF_ORIGINALS[hookName][hookEvent] = { func = hookFunc, priority = priority }
+
+            local originalFunc = hookFunc
             local originInfo = debug.getinfo( originalFunc, "S" )
             local hookFuncOrigin = originInfo.short_src
             local hookFuncLastDefined = originInfo.lastlinedefined
@@ -60,7 +85,7 @@ concommand.Add( cmd, function( ply, _, args )
                 return a, b, c, d, e, f
             end
 
-            hook.Add( hookName, hookEvent, wrapper )
+            hook.Add( hookName, hookEvent, wrapper, priority )
         end
     end
 
@@ -99,7 +124,7 @@ concommand.Add( cmd, function( ply, _, args )
                 if not orig then continue end
 
                 hook.Remove( hookName, hookEvent )
-                hook.Add( hookName, hookEvent, orig )
+                hook.Add( hookName, hookEvent, orig.func, orig.priority )
             end
         end
 


### PR DESCRIPTION
Currently, perfutils simply strips all priorities from srilion's hook lib, which can cause the code to break
This PR adds support for priorities, the method is a bit hacky though because we lack a reliable way to retrieve a hook priority

It does nothing if it is not installed